### PR TITLE
Fix submodule URL in .gitmodules for bitchat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bitchat"]
 	path = bitchat
-	url = git@github.com:derek-cook/bitchat.git
+	url = https://github.com/derek-cook/bitchat.git


### PR DESCRIPTION
## Summary
- Corrects the submodule URL for the `bitchat` submodule in the `.gitmodules` file
- Changes the URL from SSH format to HTTPS format to improve accessibility and avoid SSH key issues

## Changes

### Repository Configuration
- Updated `.gitmodules`:
  - Changed `url` from `git@github.com:derek-cook/bitchat.git` to `https://github.com/derek-cook/bitchat.git`

## Test plan
- [x] Verify that the submodule can be cloned and updated using the new HTTPS URL
- [x] Confirm no SSH key errors occur when initializing or updating submodules
- [x] Ensure existing workflows that use the submodule continue to function correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1a4c2cf0-78f8-456f-9923-297c850c42ab